### PR TITLE
irsdk.py: close telemetry file if it's not yet ready

### DIFF
--- a/irsdk.py
+++ b/irsdk.py
@@ -393,6 +393,11 @@ class IRSDK:
                     f.write(self._shared_mem)
             self._header = Header(self._shared_mem)
             self.is_initialized = self._header.version >= 1 and len(self._header.var_buf) > 0
+            if not self.is_initialized:
+                # iracing telemetry not yet ready, close
+                # it to not keep lock on the file
+                self._shared_mem.close()
+                self._shared_mem = None
 
         return self.is_initialized
 


### PR DESCRIPTION
pyirsdk opens telemetry file too soon, which causes iracing
to not being able to open telemetry file with write access,
which causes telemetry not being outputed on sim restart.

Now the proper solution would be to iracing inform us when
telemetry file is opened on its side and inform us about that.
Right now this is being checking "simrunning" on
http://127.0.0.1:32034/get_sim_status?object=simStatus page,
but iracing seems to be setting this to 1 earlier than telemetry
file is ready.

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>